### PR TITLE
Xamarin quick fixes

### DIFF
--- a/xamarin/realm-todo-dotnet/App.xaml.cs
+++ b/xamarin/realm-todo-dotnet/App.xaml.cs
@@ -24,7 +24,7 @@ namespace RealmTemplateApp
                 var appConfiguration = LoadAppConfiguration();
                 RealmApp = Realms.Sync.App.Create(appConfiguration);
 
-                var navPage = App.RealmApp.CurrentUser == null ?
+                var navPage = RealmApp.CurrentUser == null ?
                     new NavigationPage(new LoginPage()) :
                     new NavigationPage(new TaskPage());
 

--- a/xamarin/realm-todo-dotnet/LoginPage.xaml
+++ b/xamarin/realm-todo-dotnet/LoginPage.xaml
@@ -10,7 +10,7 @@
             <Entry x:Name="txtEmail" Placeholder="Email" TextChanged="Email_Entry_Completed" IsTextPredictionEnabled="False" Keyboard="Plain"/>
             <Entry x:Name="txtPassword" Placeholder="Password" IsPassword="True" TextChanged="Password_Entry_Completed" IsTextPredictionEnabled="False" Keyboard="Plain" />
             <Button x:Name="main_button" Text="Create a New Account" Clicked="Main_Button_Clicked"/>
-            <Label x:Name="switcher" FontSize="16" HorizontalOptions="Center" Text="Already have an account? Log In" TextColor="Blue" TextDecorations="Underline">
+            <Label x:Name="switcher" FontSize="14" HorizontalOptions="Center" Text="Already have an account? Log In" TextColor="Blue" TextDecorations="Underline">
                 <Label.GestureRecognizers>
                     <TapGestureRecognizer Tapped="Switcher_Tapped" />
                 </Label.GestureRecognizers>

--- a/xamarin/realm-todo-dotnet/LoginPage.xaml.cs
+++ b/xamarin/realm-todo-dotnet/LoginPage.xaml.cs
@@ -9,19 +9,11 @@ namespace RealmTemplateApp
     {
         private string email;
         private string password;
-        private bool isLoggingIn;
+        private bool isLoggingIn = false;
 
         public LoginPage()
         {
             InitializeComponent();
-        }
-
-        protected override void OnAppearing()
-        {
-            base.OnAppearing();
-            txtEmail.Text = "";
-            txtPassword.Text = "";
-            isLoggingIn = false;
         }
 
         private async void Main_Button_Clicked(object sender, EventArgs e)
@@ -91,7 +83,7 @@ namespace RealmTemplateApp
             }
             else
             {
-                label.FontSize = 16;
+                label.FontSize = 14;
                 main_button.Text = "Create a New Account";
                 label.Text = "Already have an account? Log In";
             }

--- a/xamarin/realm-todo-dotnet/TaskPage.xaml.cs
+++ b/xamarin/realm-todo-dotnet/TaskPage.xaml.cs
@@ -86,17 +86,19 @@ namespace RealmTemplateApp
 
         private async void Logout_Clicked(object sender, EventArgs e)
         {
+            // Ensure the realm is closed
+            taskRealm.Dispose();
             await App.RealmApp.CurrentUser.LogOutAsync();
-            if (Navigation.NavigationStack.Count == 1)
+
+            var root = Navigation.NavigationStack.First();
+            if (!(root is LoginPage))
             {
+                // App started with user logged in, so skipped the login page.
                 var loginPage = new LoginPage();
                 NavigationPage.SetHasBackButton(loginPage, false);
-                await Navigation.PushAsync(loginPage);
+                Navigation.InsertPageBefore(loginPage, root);
             }
-            else
-            {
-                await Navigation.PopToRootAsync();
-            }
+            await Navigation.PopToRootAsync();
         }
 
         private async void Delete_Clicked(object sender, EventArgs e)


### PR DESCRIPTION
- Fixed: When starting the app while already logged in, and then logging out, the app would not close the existing task view. Upon re-log in, crash due to realm already being opened. Also, pushing the login view is incorrect here as a second logout would then pop to root, which would have been the first task view.
- Unified font size between sign up/sign in views for less distraction.
- Fixed: When logging out and returning to the login view, the isLoggingIn could be set to the incorrect state.