### PR TITLE
Fix null reference exception on any login alert

### DIFF
--- a/xamarin/realm-todo-dotnet/LoginPage.xaml.cs
+++ b/xamarin/realm-todo-dotnet/LoginPage.xaml.cs
@@ -30,22 +30,17 @@ namespace RealmTemplateApp
 
         private async AsyncTask DoLogin()
         {
-            User user;
-            if (App.RealmApp.CurrentUser == null)
+            try
             {
-                try
-                {
-                    user = await App.RealmApp.LogInAsync(Credentials.EmailPassword(email, password));
-                }
-                catch (Exception ex)
-                {
-                    await DisplayAlert("Login Failed", ex.Message, "OK");
-                }
+                await App.RealmApp.LogInAsync(Credentials.EmailPassword(email, password));
+                var taskPage = new TaskPage();
+                NavigationPage.SetHasBackButton(taskPage, false);
+                await Navigation.PushAsync(taskPage);
             }
-
-            var taskPage = new TaskPage();
-            NavigationPage.SetHasBackButton(taskPage, false);
-            await Navigation.PushAsync(taskPage);
+            catch (Exception ex)
+            {
+                await DisplayAlert("Login Failed", ex.Message, "OK");
+            }
         }
 
         private async AsyncTask RegisterUser()


### PR DESCRIPTION
- Removed current user check since this method is only ever called in the context where
current user is definitely null
- Move unsafe code into try block