### PR TITLE
(DOCSP-23394): Remove deleteRealmIfMigrationNeeded + Lint/Prettier improvements

### DIFF
--- a/react-native/.eslintrc.js
+++ b/react-native/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
   extends: '@react-native-community',
+  rules: {
+    'no-unused-vars': 'off',
+  },
 };

--- a/react-native/package-lock.json
+++ b/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -7,7 +7,8 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prettier": "prettier --write src/*"
   },
   "dependencies": {
     "@react-native-community/masked-view": "^0.1.10",

--- a/react-native/src/App.js
+++ b/react-native/src/App.js
@@ -34,7 +34,6 @@ const App = () => {
       <RealmProvider
         // :state-start: partition-based-sync
         sync={{partitionValue: user?.id}}
-        deleteRealmIfMigrationNeeded={false}
         // :state-end:
         // :state-uncomment-start: flexible-sync
         // sync={{flexible: true}}

--- a/react-native/src/TaskSchema.js
+++ b/react-native/src/TaskSchema.js
@@ -26,5 +26,4 @@ export class Task {
 
 export default createRealmContext({
   schema: [Task.schema],
-  deleteRealmIfMigrationNeeded: true,
 });

--- a/react-native/src/TasksView.js
+++ b/react-native/src/TasksView.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState, useRef, useMemo, useCallback} from 'react';
+import React, {useEffect, useState, useMemo} from 'react';
 import {BSON} from 'realm';
 import {useUser} from '@realm/react';
 import {SafeAreaProvider} from 'react-native-safe-area-context';


### PR DESCRIPTION
JIRA: 
- https://jira.mongodb.org/browse/DOCSP-23394

Additional Fixes (not included within JIRA ticket):
- Added prettier script to package.json
- Removed rule "no-unused-vars" (since some variables are commented out for the template, but when they are generated via bluehawk, such as if they are used for the flexified template state, then they are used)
- Removed uneeded variables in TasksView.js (these variables are neither used by the flexible template state or the pbs template state)