### PR TITLE
(DOCSP-26228): Update Realm Flutter SDK to 0.6.0+beta

### DIFF
--- a/flutter_todo/README.md
+++ b/flutter_todo/README.md
@@ -1,6 +1,7 @@
 # Realm Flutter Todo
 
-A todo list application built with the [Realm Flutter SDK](https://www.mongodb.com/docs/realm/sdk/flutter/).
+A todo list application built with the [Realm Flutter SDK](https://www.mongodb.com/docs/realm/sdk/flutter/)
+and [Atlas Device Sync](https://www.mongodb.com/docs/atlas/app-services/sync/).
 
 ## Getting Started
 
@@ -12,3 +13,7 @@ A todo list application built with the [Realm Flutter SDK](https://www.mongodb.c
      `flutter run` if only one emulator or iOS Simulator is available.
      or get the device id with `flutter devices` and start the app `flutter run -d <device-id>`
      For more information on running a Flutter app see the [Flutter Test Drive documentation](https://docs.flutter.dev/get-started/test-drive).
+
+## Build on the App
+
+Learn about how to build a feature on top of this application in the [Flutter Device Sync Tutorial](https://www.mongodb.com/docs/atlas/app-services/tutorial/flutter/).

--- a/flutter_todo/assets/config/realm.json
+++ b/flutter_todo/assets/config/realm.json
@@ -1,4 +1,4 @@
 {
-  "appId": "flex_sync_template_new-uiwye",
+  "appId": "mytutorialapp-xjkmu",
   "baseUrl": "https://realm.mongodb.com"
 }

--- a/flutter_todo/lib/realm/schemas.g.dart
+++ b/flutter_todo/lib/realm/schemas.g.dart
@@ -6,7 +6,7 @@ part of 'schemas.dart';
 // RealmObjectGenerator
 // **************************************************************************
 
-class Item extends _Item with RealmEntity, RealmObject {
+class Item extends _Item with RealmEntity, RealmObjectBase, RealmObject {
   static var _defaultsSet = false;
 
   Item(
@@ -16,47 +16,50 @@ class Item extends _Item with RealmEntity, RealmObject {
     bool isComplete = false,
   }) {
     if (!_defaultsSet) {
-      _defaultsSet = RealmObject.setDefaults<Item>({
+      _defaultsSet = RealmObjectBase.setDefaults<Item>({
         'isComplete': false,
       });
     }
-    RealmObject.set(this, '_id', id);
-    RealmObject.set(this, 'isComplete', isComplete);
-    RealmObject.set(this, 'summary', summary);
-    RealmObject.set(this, 'owner_id', ownerId);
+    RealmObjectBase.set(this, '_id', id);
+    RealmObjectBase.set(this, 'isComplete', isComplete);
+    RealmObjectBase.set(this, 'summary', summary);
+    RealmObjectBase.set(this, 'owner_id', ownerId);
   }
 
   Item._();
 
   @override
-  ObjectId get id => RealmObject.get<ObjectId>(this, '_id') as ObjectId;
+  ObjectId get id => RealmObjectBase.get<ObjectId>(this, '_id') as ObjectId;
   @override
-  set id(ObjectId value) => throw RealmUnsupportedSetError();
+  set id(ObjectId value) => RealmObjectBase.set(this, '_id', value);
 
   @override
-  bool get isComplete => RealmObject.get<bool>(this, 'isComplete') as bool;
+  bool get isComplete => RealmObjectBase.get<bool>(this, 'isComplete') as bool;
   @override
-  set isComplete(bool value) => RealmObject.set(this, 'isComplete', value);
+  set isComplete(bool value) => RealmObjectBase.set(this, 'isComplete', value);
 
   @override
-  String get summary => RealmObject.get<String>(this, 'summary') as String;
+  String get summary => RealmObjectBase.get<String>(this, 'summary') as String;
   @override
-  set summary(String value) => RealmObject.set(this, 'summary', value);
+  set summary(String value) => RealmObjectBase.set(this, 'summary', value);
 
   @override
-  String get ownerId => RealmObject.get<String>(this, 'owner_id') as String;
+  String get ownerId => RealmObjectBase.get<String>(this, 'owner_id') as String;
   @override
-  set ownerId(String value) => RealmObject.set(this, 'owner_id', value);
+  set ownerId(String value) => RealmObjectBase.set(this, 'owner_id', value);
 
   @override
   Stream<RealmObjectChanges<Item>> get changes =>
-      RealmObject.getChanges<Item>(this);
+      RealmObjectBase.getChanges<Item>(this);
+
+  @override
+  Item freeze() => RealmObjectBase.freezeObject<Item>(this);
 
   static SchemaObject get schema => _schema ??= _initSchema();
   static SchemaObject? _schema;
   static SchemaObject _initSchema() {
-    RealmObject.registerFactory(Item._);
-    return const SchemaObject(Item, 'Item', [
+    RealmObjectBase.registerFactory(Item._);
+    return const SchemaObject(ObjectType.realmObject, Item, 'Item', [
       SchemaProperty('_id', RealmPropertyType.objectid,
           mapTo: '_id', primaryKey: true),
       SchemaProperty('isComplete', RealmPropertyType.bool),

--- a/flutter_todo/macos/Podfile.lock
+++ b/flutter_todo/macos/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - FlutterMacOS (1.0.0)
   - path_provider_macos (0.0.1):
     - FlutterMacOS
-  - "realm (0.4.0+beta)":
+  - "realm (0.6.0+beta)":
     - FlutterMacOS
 
 DEPENDENCIES:
@@ -19,9 +19,9 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/realm/macos
 
 SPEC CHECKSUMS:
-  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
-  realm: c17a4fef20bc1074ed910d7eeca53378d3e4c295
+  realm: 9843c45f45ec143b9307cf7401f0254afc38fad7
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
 

--- a/flutter_todo/pubspec.lock
+++ b/flutter_todo/pubspec.lock
@@ -99,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.3.2"
+  cancellation_token:
+    dependency: transitive
+    description:
+      name: cancellation_token
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.0"
   characters:
     dependency: transitive
     description:
@@ -276,7 +283,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.0"
+    version: "4.7.0"
   lints:
     dependency: transitive
     description:
@@ -451,21 +458,21 @@ packages:
       name: realm
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0+beta"
+    version: "0.6.0+beta"
   realm_common:
     dependency: transitive
     description:
       name: realm_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0+beta"
+    version: "0.6.0+beta"
   realm_generator:
     dependency: transitive
     description:
       name: realm_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0+beta"
+    version: "0.6.0+beta"
   sane_uuid:
     dependency: transitive
     description:

--- a/flutter_todo/pubspec.yaml
+++ b/flutter_todo/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  realm: ^0.5.0+beta
+  realm: ^0.6.0+beta
   flutter_slidable: ^2.0.0
   path_provider: ^2.0.10
 


### PR DESCRIPTION
Update Realm Flutter SDK to 0.6.0+beta. fixes a bug wher schema migrations don't work when doing non-breaking client side changes. 

also updated README to reference the tutorial and app id to one that is currently active.