### PR TITLE
Add Zip download App ID instructions to READMEs

### DIFF
--- a/sync-todo/v1/client/flutter_todo/README.md
+++ b/sync-todo/v1/client/flutter_todo/README.md
@@ -23,6 +23,14 @@ Once you have created the App Services App, replace any value in this client's
 `appId` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `flutter_todo/assets/config/realm.json` 
+with your App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
 ## Run the App
 
 1. Enter the project

--- a/sync-todo/v1/client/kotlin-sdk/README.md
+++ b/sync-todo/v1/client/kotlin-sdk/README.md
@@ -20,6 +20,14 @@ Once you have created the App Services App, replace any value in this client's
 `realm_app_id` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `realm_app_id` field in `app/src/main/res/values/realm.xml` 
+with your App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
 ## Run the app
 
 - Open this directory in Android Studio.

--- a/sync-todo/v1/client/react-native/README.md
+++ b/sync-todo/v1/client/react-native/README.md
@@ -20,6 +20,14 @@ Once you have created the App Services App, replace any value in this client's
 `appId` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `react-native/realm.json` with your 
+App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
 ## How to Run the Application for Mac Users:
 
 - make sure you are in this directory

--- a/sync-todo/v1/client/swiftui/README.md
+++ b/sync-todo/v1/client/swiftui/README.md
@@ -22,6 +22,16 @@ Once you have created the App Services App, replace any value in this client's
 `appId` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `App/Realm.plist` with your App Services 
+App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+If you did not replace the App ID, you may see an `Error: unsupported URL` message.
+
 ## Run the app
 
 - Open App.xcodeproj in Xcode.

--- a/sync-todo/v1/client/xamarin/README.md
+++ b/sync-todo/v1/client/xamarin/README.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 
-Ensure realm-todo-dotnet/realm.json exists and contains the following properties:
+Ensure `realm-todo-dotnet/realm.json` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
 - **baseUrl:** the Realm backend URL. Should be https://realm.mongodb.com in most cases.
@@ -19,6 +19,14 @@ in the Atlas App Services documentation page:
 Once you have created the App Services App, replace any value in this client's
 `appId` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `realm-todo-dotnet/realm.json` with your 
+App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
 ## Run the app
 

--- a/sync-todo/v1/generated/flutter_todo/README.md
+++ b/sync-todo/v1/generated/flutter_todo/README.md
@@ -23,6 +23,14 @@ Once you have created the App Services App, replace any value in this client's
 `appId` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `flutter_todo/assets/config/realm.json` 
+with your App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
 ## Run the App
 
 1. Enter the project

--- a/sync-todo/v1/generated/kotlin-sdk/README.md
+++ b/sync-todo/v1/generated/kotlin-sdk/README.md
@@ -20,6 +20,14 @@ Once you have created the App Services App, replace any value in this client's
 `realm_app_id` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `realm_app_id` field in `app/src/main/res/values/realm.xml` 
+with your App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
 ## Run the app
 
 - Open this directory in Android Studio.

--- a/sync-todo/v1/generated/react-native/README.md
+++ b/sync-todo/v1/generated/react-native/README.md
@@ -20,6 +20,14 @@ Once you have created the App Services App, replace any value in this client's
 `appId` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `react-native/realm.json` with your 
+App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
 ## How to Run the Application for Mac Users:
 
 - make sure you are in this directory

--- a/sync-todo/v1/generated/swiftui/README.md
+++ b/sync-todo/v1/generated/swiftui/README.md
@@ -22,6 +22,16 @@ Once you have created the App Services App, replace any value in this client's
 `appId` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `App/Realm.plist` with your App Services 
+App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+If you did not replace the App ID, you may see an `Error: unsupported URL` message.
+
 ## Run the app
 
 - Open App.xcodeproj in Xcode.

--- a/sync-todo/v1/generated/xamarin/README.md
+++ b/sync-todo/v1/generated/xamarin/README.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 
-Ensure realm-todo-dotnet/realm.json exists and contains the following properties:
+Ensure `realm-todo-dotnet/realm.json` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
 - **baseUrl:** the Realm backend URL. Should be https://realm.mongodb.com in most cases.
@@ -19,6 +19,14 @@ in the Atlas App Services documentation page:
 Once you have created the App Services App, replace any value in this client's
 `appId` field with your App Services App ID. For help finding this ID, refer
 to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `realm-todo-dotnet/realm.json` with your 
+App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
 ## Run the app
 

--- a/sync-todo/v2/client/flutter/README.md
+++ b/sync-todo/v2/client/flutter/README.md
@@ -3,6 +3,34 @@
 A todo list application built with the [Realm Flutter SDK](https://www.mongodb.com/docs/realm/sdk/flutter/)
 and [Atlas Device Sync](https://www.mongodb.com/docs/atlas/app-services/sync/).
 
+## Configuration
+
+Ensure `flutter_todo/assets/config/realm.json` exists and contains the following properties:
+
+- **appId:** your Atlas App Services App ID.
+- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+
+### Cloning from GitHub
+
+If you have cloned this repository from the GitHub
+[mongodb/template-app-dart-flutter-todo](https://github.com/mongodb/template-app-dart-flutter-todo.git)
+repository, you must create a separate App Services App with Device Sync
+enabled to use this client. You can find information about how to do this
+in the Atlas App Services documentation page:
+[Template Apps -> Create a Template App](https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#create-a-template-app)
+
+Once you have created the App Services App, replace any value in this client's
+`appId` field with your App Services App ID. For help finding this ID, refer
+to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `flutter_todo/assets/config/realm.json` 
+with your App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
 ## Getting Started
 
 1. Clone and enter the project
@@ -17,3 +45,7 @@ and [Atlas Device Sync](https://www.mongodb.com/docs/atlas/app-services/sync/).
 ## Build on the App
 
 Learn about how to build a feature on top of this application in the [Flutter Device Sync Tutorial](https://www.mongodb.com/docs/atlas/app-services/tutorial/flutter/).
+
+## Issues
+
+Please report issues with the template at https://github.com/mongodb-university/realm-template-apps/issues/new .

--- a/sync-todo/v2/client/kotlin-sdk/README.md
+++ b/sync-todo/v2/client/kotlin-sdk/README.md
@@ -1,10 +1,31 @@
 # Realm Kotlin SDK Template App
-
 ## Configuration
 
-Ensure app/src/main/res/values/realm.xml exists and contains the following properties:
+Ensure `app/src/main/res/values/realm.xml` exists and contains the following properties:
 
-- **realm_app_id:** your Realm app ID, which can be found in the Realm app UI at https://realm.mongodb.com
+- **realm_app_id:** your Atlas App Services App ID.
+- **realm_base_url** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+
+### Cloning from GitHub
+
+If you have cloned this repository from the GitHub
+[mongodb/template-app-kotlin-todo](https://github.com/mongodb/template-app-kotlin-todo.git)
+repository, you must create a separate App Services App with Device Sync
+enabled to use this client. You can find information about how to do this
+in the Atlas App Services documentation page:
+[Template Apps -> Create a Template App](https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#create-a-template-app)
+
+Once you have created the App Services App, replace any value in this client's
+`realm_app_id` field with your App Services App ID. For help finding this ID, refer
+to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `realm_app_id` field in `app/src/main/res/values/realm.xml` 
+with your App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
 ## Run the app
 

--- a/sync-todo/v2/client/maui/README.md
+++ b/sync-todo/v2/client/maui/README.md
@@ -10,6 +10,10 @@ namespace RealmTodo.Services
     public static class RealmService
     {
         private const string appId = "****";
+        ...
+    }
+    ...
+}
 ```
 
 Replace this string `appId` value with your App Services App ID. For help 

--- a/sync-todo/v2/client/maui/README.md
+++ b/sync-todo/v2/client/maui/README.md
@@ -1,0 +1,33 @@
+﻿# Maui C# Template App
+
+## Configuration
+
+The App ID is located in `RealmTodo/Services/RealmService.cs`:
+
+```cs
+namespace RealmTodo.Services
+{
+    public static class RealmService
+    {
+        private const string appId = "****";
+```
+
+Replace this string `appId` value with your App Services App ID. For help 
+finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+### Cloning from GitHub
+
+If you have cloned this repository from the GitHub
+[mongodb/template-app-xamarin-todo](https://github.com/mongodb/template-app-xamarin-todo.git)
+repository, you must create a separate App Services App with Device Sync
+enabled to use this client. You can find information about how to do this
+in the Atlas App Services documentation page:
+[Template Apps -> Create a Template App](https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#create-a-template-app)
+
+Once you have created the App Services App, update the `appId` per the 
+above instructions.
+
+## Issues
+
+Please report issues with the template at https://github.com/mongodb-university/realm-template-apps/issues/new .

--- a/sync-todo/v2/client/react-native/README.md
+++ b/sync-todo/v2/client/react-native/README.md
@@ -11,10 +11,31 @@
 
 ## Configuration
 
-Ensure ./realm.json exists and contains the following properties:
+Ensure `realm.json` exists and contains the following properties:
 
-- **appId:** your Realm app ID, which can be found in the Realm app UI at https://realm.mongodb.com
-- **baseUrl:** the Realm backend URL. Should be https://realm.mongodb.com in most cases.
+- **appId:** your Atlas App Services App ID.
+- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+
+### Cloning from GitHub
+
+If you have cloned this repository from the GitHub
+[mongodb/template-app-react-native-todo](https://github.com/mongodb/template-app-react-native-todo.git)
+repository, you must create a separate App Services App with Device Sync
+enabled to use this client. You can find information about how to do this
+in the Atlas App Services documentation page:
+[Template Apps -> Create a Template App](https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#create-a-template-app)
+
+Once you have created the App Services App, replace any value in this client's
+`appId` field with your App Services App ID. For help finding this ID, refer
+to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `realm.json` with your 
+App Services App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
 
 ## How to Run the Application:
 - Make sure you are in this directory

--- a/sync-todo/v2/client/swiftui/README.md
+++ b/sync-todo/v2/client/swiftui/README.md
@@ -4,10 +4,33 @@ This project uses Swift Package Manager (SPM) to load dependencies.
 
 ## Configuration
 
-Ensure App/Realm.plist exists and contains the following properties:
+Ensure `App/Realm.plist` exists and contains the following properties:
 
-- **appId:** your Realm app ID, which can be found in the Realm app UI at https://realm.mongodb.com
-- **baseUrl:** the Realm backend URL. Should be https://realm.mongodb.com in most cases.
+- **appId:** your Atlas App Services App ID.
+- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+
+### Cloning from GitHub
+
+If you have cloned this repository from the GitHub
+[mongodb/template-app-swiftui-todo](https://github.com/mongodb/template-app-swiftui-todo.git)
+repository, you must create a separate App Services App with Device Sync
+enabled to use this client. You can find information about how to do this
+in the Atlas App Services documentation page:
+[Template Apps -> Create a Template App](https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#create-a-template-app)
+
+Once you have created the App Services App, replace any value in this client's
+`appId` field with your App Services App ID. For help finding this ID, refer
+to: [Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+### Download the Client as a Zip File
+
+If you have downloaded this client as a .zip file from the Atlas App Services
+UI, it does not contain the App Services App ID. You must replace any value 
+in this client's `appId` field in `App/Realm.plist` with your App Services 
+App ID. For help finding this ID, refer to: 
+[Find Your Project or App Id](https://www.mongodb.com/docs/atlas/app-services/reference/find-your-project-or-app-id/)
+
+If you did not replace the App ID, you may see an `Error: unsupported URL` message.
 
 ## Run the app
 


### PR DESCRIPTION
When you download the template app client as a Zip file, the app is not populated with an App ID. Adding instructions to the READMEs about how to find and populate the App IDs in this scenario.

Also, adding some things to the v2 READMEs that were missing.

Maui was missing a README entirely. I've added config details here, but we should probably add any notable instructions to run the app and/or change the namespace similar to the Xamarin README.