### PR TITLE
Update generated SwiftUI App SDK version

### DIFF
--- a/sync-todo/v2/generated/swiftui/App.xcodeproj/project.pbxproj
+++ b/sync-todo/v2/generated/swiftui/App.xcodeproj/project.pbxproj
@@ -418,8 +418,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
-				kind = exactVersion;
-				version = 10.32.3;
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.35.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Forgot to generate the new version of the SwiftUI App after bumping the SDK version in the base app.