### PR TITLE
Fix dataExplorerLink ref in Kotlin template app

### DIFF
--- a/sync-todo/v2/client/kotlin-sdk/app/src/main/java/com/mongodb/app/ComposeItemActivity.kt
+++ b/sync-todo/v2/client/kotlin-sdk/app/src/main/java/com/mongodb/app/ComposeItemActivity.kt
@@ -198,7 +198,7 @@ fun TaskListScaffold(
         )
         addStringAnnotation(
             tag = "URL",
-            annotation = stringResource(id = R.string.dataExplorerLink),
+            annotation = stringResource(id = R.string.realm_data_explorer_link),
             start = startIndex,
             end = endIndex
         )

--- a/sync-todo/v2/client/kotlin-sdk/app/src/main/java/com/mongodb/app/TemplateApp.kt
+++ b/sync-todo/v2/client/kotlin-sdk/app/src/main/java/com/mongodb/app/TemplateApp.kt
@@ -28,6 +28,6 @@ class TemplateApp: Application() {
         // https://github.com/mongodb/template-app-kotlin-todo, 
         // it does not contain the data explorer link. Download the
         // app template from the Atlas UI to view a link to your data.
-        Log.v(TAG(),"To see your data in Atlas, follow this link:" + getString(R.string.dataExplorerLink))
+        Log.v(TAG(),"To see your data in Atlas, follow this link:" + getString(R.string.realm_data_explorer_link))
     }
 }

--- a/sync-todo/v2/client/kotlin-sdk/app/src/main/java/com/mongodb/app/ui/tasks/AddItem.kt
+++ b/sync-todo/v2/client/kotlin-sdk/app/src/main/java/com/mongodb/app/ui/tasks/AddItem.kt
@@ -47,7 +47,7 @@ fun AddItemPrompt(viewModel: AddItemViewModel) {
             // https://github.com/mongodb/template-app-kotlin-todo, 
             // it does not contain the data explorer link. Download the
             // app template from the Atlas UI to view a link to your data.
-            var link = stringResource(R.string.dataExplorerLink)
+            var link = stringResource(R.string.realm_data_explorer_link)
             Button(
                 colors = buttonColors(containerColor = Purple200),
                 onClick = {

--- a/sync-todo/v2/generated/kotlin-sdk/app/src/main/java/com/mongodb/app/ComposeItemActivity.kt
+++ b/sync-todo/v2/generated/kotlin-sdk/app/src/main/java/com/mongodb/app/ComposeItemActivity.kt
@@ -198,7 +198,7 @@ fun TaskListScaffold(
         )
         addStringAnnotation(
             tag = "URL",
-            annotation = stringResource(id = R.string.dataExplorerLink),
+            annotation = stringResource(id = R.string.realm_data_explorer_link),
             start = startIndex,
             end = endIndex
         )

--- a/sync-todo/v2/generated/kotlin-sdk/app/src/main/java/com/mongodb/app/TemplateApp.kt
+++ b/sync-todo/v2/generated/kotlin-sdk/app/src/main/java/com/mongodb/app/TemplateApp.kt
@@ -28,6 +28,6 @@ class TemplateApp: Application() {
         // https://github.com/mongodb/template-app-kotlin-todo, 
         // it does not contain the data explorer link. Download the
         // app template from the Atlas UI to view a link to your data.
-        Log.v(TAG(),"To see your data in Atlas, follow this link:" + getString(R.string.dataExplorerLink))
+        Log.v(TAG(),"To see your data in Atlas, follow this link:" + getString(R.string.realm_data_explorer_link))
     }
 }

--- a/sync-todo/v2/generated/kotlin-sdk/app/src/main/java/com/mongodb/app/ui/tasks/AddItem.kt
+++ b/sync-todo/v2/generated/kotlin-sdk/app/src/main/java/com/mongodb/app/ui/tasks/AddItem.kt
@@ -47,7 +47,7 @@ fun AddItemPrompt(viewModel: AddItemViewModel) {
             // https://github.com/mongodb/template-app-kotlin-todo, 
             // it does not contain the data explorer link. Download the
             // app template from the Atlas UI to view a link to your data.
-            var link = stringResource(R.string.dataExplorerLink)
+            var link = stringResource(R.string.realm_data_explorer_link)
             Button(
                 colors = buttonColors(containerColor = Purple200),
                 onClick = {


### PR DESCRIPTION
In Kotlin template app only, the string resource in `atlasConfig.xml` is generated as `realm_data_explorer_link`, which doesn't match the in-code ref.

- [x] Rename `dataExplorerLink` to `realm_data_explorer_link` in Kotlin app code 
- [x] Generate updated Kotlin app 
- [ ] Confirm successful build