### PR TITLE
BAAS-22432: remove undeclared function in tiered sync app function config

### DIFF
--- a/other/flex-sync-guides/backend/tiered/functions/config.json
+++ b/other/flex-sync-guides/backend/tiered/functions/config.json
@@ -8,11 +8,6 @@
         "private": true
     },
     {
-        "name": "subscribeToUser",
-        "private": false,
-        "disable_arg_logs": true
-    },
-    {
         "name": "joinTeam",
         "private": false,
         "run_as_system": true


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/BAAS-22432

While working on updating our TSA parsing code, I ran into a validation error because one of the apps had a function defined in the functions config that didn't have a corresponding source file, so I removed the declaration