### PR TITLE
BAAS-26004: Update trigger template to use event_processors syntax for function name

### DIFF
--- a/other/triggers/triggers/trigger0.json
+++ b/other/triggers/triggers/trigger0.json
@@ -15,6 +15,12 @@
         "full_document_before_change": false,
         "unordered": false
     },
-    "function_name": "updateCollectionView",
-    "disabled": false
+    "disabled": false,
+    "event_processors": {
+        "FUNCTION": {
+            "config": {
+                "function_name": "updateCollectionView"
+            }
+        }
+    }
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/BAAS-26004

See https://github.com/10gen/baas/pull/11842 for the wider context, but the tl;dr is that having the `function_name` as a top-level field on the trigger config was causing some trouble with our new code for parsing backend templates. Once that PR is merged, the top-level `function_name` would work, but I'm opting to put this up just to have the trigger reflect our current structure