### PR TITLE
(DOCSP-35276): Update baseURL and fix remaining dataExplorerLink issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ For bucket access, consult the Realm docs team.
 
 ## Sync-todo Versions
 
-- **v0**: (Deprecated) A partition-based sync "task tracker" app.
-- **v1**: (Deprecated) The task tracker app, now with flexible sync!
 - **v2**: (Current) A todo app with a flexible sync backend that has a few new nifty features.
 
 ## About "generated"
@@ -51,12 +49,13 @@ A GitHub Action creates "artifact repos" of a few subdirectories so that the cli
    `generated` directory.
 
 2. Be sure your project uses a `realm.json` file (or `.xml`, or `.plist`...) to
-   get the app id and base url info:
+   get the app id, base url info, and data explorer link:
 
    ```
    {
       "appId": "todo-sync-jxgjv",
-      "baseUrl": "https://realm.mongodb.com"
+      "baseUrl": "https://services.cloud.mongodb.com",
+      "dataExplorerLink": "https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find"
    }
    ```
 

--- a/create-metadata-file.sh
+++ b/create-metadata-file.sh
@@ -13,7 +13,7 @@ app_description=$(npx mongodb-realm-cli app describe | tail -n +2)
 APP_ID=$(jq -r '.client_app_id' <<< "$app_description")
 REALM_URL=$(jq -r '.realm_url' <<< "$app_description")
 
-DEPLOYMENT_REGEX='https:\/\/(((.+)\.(.+))\.)?realm.mongodb.com'
+DEPLOYMENT_REGEX='https:\/\/(((.+)\.(.+))\.)?services.cloud.mongodb.com'
 [[ $REALM_URL =~ $DEPLOYMENT_REGEX ]]
 REGION_DOT_CLOUD="${BASH_REMATCH[2]}"
 # REGION="${BASH_REMATCH[3]}"
@@ -33,7 +33,7 @@ metadata_file=$(
     --arg DATA_API_BASE_URL "$DATA_API_BASE_URL" \
     '{
       "appId": $APP_ID,
-      "baseUrl": "https://realm.mongodb.com",
+      "baseUrl": "https://services.cloud.mongodb.com",
       "appUrl": .realm_url | split("/") | del(.[] | select(. == "dashboard")) | join("/"),
       "dataSourceName": .data_sources[0].name,
       "clientApiBaseUrl": $CLIENT_API_BASE_URL,

--- a/other/flex-sync-guides/client/src/realm.json
+++ b/other/flex-sync-guides/client/src/realm.json
@@ -8,5 +8,5 @@
   // :state-start: restricted-feed
   "appId": "flexsyncpermissions-jojzp",
   // :state-end:
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com"
 }

--- a/other/flex-sync-guides/generated/add-collaborators/src/realm.json
+++ b/other/flex-sync-guides/generated/add-collaborators/src/realm.json
@@ -1,4 +1,4 @@
 {
   "appId": "<your-app-id>",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com"
 }

--- a/other/flex-sync-guides/generated/restricted-feed/src/realm.json
+++ b/other/flex-sync-guides/generated/restricted-feed/src/realm.json
@@ -1,4 +1,4 @@
 {
   "appId": "<your-app-id>",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com"
 }

--- a/other/flex-sync-guides/generated/tiered/src/realm.json
+++ b/other/flex-sync-guides/generated/tiered/src/realm.json
@@ -1,4 +1,4 @@
 {
   "appId": "<your-app-id>",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com"
 }

--- a/other/flex-sync-guides/template-realm.json
+++ b/other/flex-sync-guides/template-realm.json
@@ -1,4 +1,4 @@
 {
   "appId": "<your-app-id>",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com"
 }

--- a/other/web-js/CONTRIBUTING.rst
+++ b/other/web-js/CONTRIBUTING.rst
@@ -184,10 +184,10 @@ The result should look like the following but with values specific to your App:
 
    {
      "appId": "myapp-abcde",
-     "baseUrl": "https://realm.mongodb.com",
-     "appUrl": "https://realm.mongodb.com/groups/642da640aa2afcfdaada4834/apps/642da64426fda9654422da0e/",
+     "baseUrl": "https://services.cloud.mongodb.com",
+     "appUrl": "https://services.cloud.mongodb.com/groups/642da640aa2afcfdaada4834/apps/642da64426fda9654422da0e/",
      "dataSourceName": "mongodb-atlas",
-     "clientApiBaseUrl": "https://realm.mongodb.com",
+     "clientApiBaseUrl": "https://services.cloud.mongodb.com",
      "dataApiBaseUrl": "https://data.mongodb-api.com"
    }
 

--- a/other/web-js/client/src/atlasConfig.json
+++ b/other/web-js/client/src/atlasConfig.json
@@ -1,8 +1,8 @@
 {
   "appId": "todo-data-api-moifs",
-  "baseUrl": "https://realm.mongodb.com",
-  "appUrl": "https://realm.mongodb.com/groups/5b2ec426970199272441a214/apps/63ee5762b7dfee2f43183b33",
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "appUrl": "https://services.cloud.mongodb.com/groups/5b2ec426970199272441a214/apps/63ee5762b7dfee2f43183b33",
   "dataSourceName": "mongodb-atlas",
-  "clientApiBaseUrl": "https://realm.mongodb.com",
+  "clientApiBaseUrl": "https://services.cloud.mongodb.com",
   "dataApiBaseUrl": "https://data.mongodb-api.com"
 }

--- a/other/web-js/client/src/client-api.js
+++ b/other/web-js/client/src/client-api.js
@@ -271,7 +271,7 @@ export class CredentialStorage {
  * {
  *   error: 'name already in use',
  *   error_code: 'AccountNameInUse',
- *   link: 'https://realm.mongodb.com/groups/{groupId}/apps/{appId}/logs?co_id=63f506d9d243efe65aa33430'
+ *   link: 'https://services.cloud.mongodb.com/groups/{groupId}/apps/{appId}/logs?co_id=63f506d9d243efe65aa33430'
  * }
  */
 export class ClientApiError extends Error {

--- a/other/web-js/generated/prod-data-api/src/atlasConfig.json
+++ b/other/web-js/generated/prod-data-api/src/atlasConfig.json
@@ -1,8 +1,8 @@
 {
   "appId": "<your-app-id>",
-  "baseUrl": "https://realm.mongodb.com",
-  "appUrl": "https://realm.mongodb.com/groups/<your-group-id>/apps/<app-hash>/",
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "appUrl": "https://services.cloud.mongodb.com/groups/<your-group-id>/apps/<app-hash>/",
   "dataSourceName": "mongodb-atlas",
-  "clientApiBaseUrl": "https://realm.mongodb.com",
+  "clientApiBaseUrl": "https://services.cloud.mongodb.com",
   "dataApiBaseUrl": "https://data.mongodb-api.com"
 }

--- a/other/web-js/generated/prod-data-api/src/client-api.js
+++ b/other/web-js/generated/prod-data-api/src/client-api.js
@@ -271,7 +271,7 @@ export class CredentialStorage {
  * {
  *   error: 'name already in use',
  *   error_code: 'AccountNameInUse',
- *   link: 'https://realm.mongodb.com/groups/{groupId}/apps/{appId}/logs?co_id=63f506d9d243efe65aa33430'
+ *   link: 'https://services.cloud.mongodb.com/groups/{groupId}/apps/{appId}/logs?co_id=63f506d9d243efe65aa33430'
  * }
  */
 export class ClientApiError extends Error {

--- a/other/web-js/generated/prod-graphql/src/atlasConfig.json
+++ b/other/web-js/generated/prod-graphql/src/atlasConfig.json
@@ -1,8 +1,8 @@
 {
   "appId": "<your-app-id>",
-  "baseUrl": "https://realm.mongodb.com",
-  "appUrl": "https://realm.mongodb.com/groups/<your-group-id>/apps/<app-hash>/",
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "appUrl": "https://services.cloud.mongodb.com/groups/<your-group-id>/apps/<app-hash>/",
   "dataSourceName": "mongodb-atlas",
-  "clientApiBaseUrl": "https://realm.mongodb.com",
+  "clientApiBaseUrl": "https://services.cloud.mongodb.com",
   "dataApiBaseUrl": "https://data.mongodb-api.com"
 }

--- a/other/web-js/generated/prod-mql/src/atlasConfig.json
+++ b/other/web-js/generated/prod-mql/src/atlasConfig.json
@@ -1,8 +1,8 @@
 {
   "appId": "<your-app-id>",
-  "baseUrl": "https://realm.mongodb.com",
-  "appUrl": "https://realm.mongodb.com/groups/<your-group-id>/apps/<app-hash>/",
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "appUrl": "https://services.cloud.mongodb.com/groups/<your-group-id>/apps/<app-hash>/",
   "dataSourceName": "mongodb-atlas",
-  "clientApiBaseUrl": "https://realm.mongodb.com",
+  "clientApiBaseUrl": "https://services.cloud.mongodb.com",
   "dataApiBaseUrl": "https://data.mongodb-api.com"
 }

--- a/other/web-js/template-realm.json
+++ b/other/web-js/template-realm.json
@@ -1,8 +1,8 @@
 {
   "appId": "<your-app-id>",
-  "baseUrl": "https://realm.mongodb.com",
-  "appUrl": "https://realm.mongodb.com/groups/<your-group-id>/apps/<app-hash>/",
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "appUrl": "https://services.cloud.mongodb.com/groups/<your-group-id>/apps/<app-hash>/",
   "dataSourceName": "mongodb-atlas",
-  "clientApiBaseUrl": "https://realm.mongodb.com",
+  "clientApiBaseUrl": "https://services.cloud.mongodb.com",
   "dataApiBaseUrl": "https://data.mongodb-api.com"
 }

--- a/sync-todo/v2/client/flutter/README.md
+++ b/sync-todo/v2/client/flutter/README.md
@@ -10,7 +10,7 @@ run this template app.
 For this template app to work, you must ensure that `/assets/config/atlasConfig.json` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
 - **dataExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
 
 ### Using the Atlas App Services UI

--- a/sync-todo/v2/client/flutter/README.md
+++ b/sync-todo/v2/client/flutter/README.md
@@ -11,11 +11,11 @@ For this template app to work, you must ensure that `/assets/config/atlasConfig.
 
 - **appId:** your Atlas App Services App ID.
 - **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
-- **atlasExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
+- **dataExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose
 **Real Time Sync**, and then follow the prompts. While the backend app is being
 created, you can download this Flutter template app pre-configured for your new
 app.
@@ -46,8 +46,8 @@ For this template app to work, you must ensure that
 `/assets/config/atlasConfig.json` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
-- **atlasExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
+- **dataExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
 
 Once you have created the App Services App, replace any value in the
 `appId` field with your App Services App ID. For help finding this ID, refer

--- a/sync-todo/v2/client/flutter/assets/config/atlasConfig.json
+++ b/sync-todo/v2/client/flutter/assets/config/atlasConfig.json
@@ -1,6 +1,6 @@
 {
   "appId": "sync-todo-v2-oxdgx",
-  "baseUrl": "https://realm.mongodb.com",
+  "baseUrl": "https://services.cloud.mongodb.com",
   "dataExplorerLink": "",
   "dataSourceName": "mongodb-atlas"
 }

--- a/sync-todo/v2/client/kotlin-sdk/README.md
+++ b/sync-todo/v2/client/kotlin-sdk/README.md
@@ -5,12 +5,12 @@
 Ensure `app/src/main/res/values/atlasConfig.xml` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
 - **dataExplorerLink:** the link to the Atlas cluster's collections.
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose 
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose 
 **Real Time Sync**, and then follow the prompts. While the backend app is being 
 created, you can download this Kotlin template app pre-configured for your new 
 app.

--- a/sync-todo/v2/client/kotlin-sdk/app/src/main/res/values/atlasConfig.xml
+++ b/sync-todo/v2/client/kotlin-sdk/app/src/main/res/values/atlasConfig.xml
@@ -1,5 +1,5 @@
 <resources>
   <string name="realm_app_id">PUT YOUR APP ID HERE</string>
-  <string name="realm_base_url">https://realm.mongodb.com</string>
-  <string name="dataExplorerLink">https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find</string>
+  <string name="realm_base_url">https://services.cloud.mongodb.com</string>
+  <string name="realm_data_explorer_link">https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find</string>
 </resources>

--- a/sync-todo/v2/client/maui/README.md
+++ b/sync-todo/v2/client/maui/README.md
@@ -12,7 +12,7 @@ The App ID is located in `atlasConfig.json`:
 ```json
 {
   "appId": "********",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com"
 }
 ```
 
@@ -20,7 +20,7 @@ You will need to change the value of `appId` value with your App Services App ID
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose 
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose 
 **Real Time Sync**, and then follow the prompts. While the backend app is being 
 created, you can download this MAUI template app pre-configured for your new 
 app.

--- a/sync-todo/v2/client/maui/RealmTodo/atlasConfig.json
+++ b/sync-todo/v2/client/maui/RealmTodo/atlasConfig.json
@@ -1,5 +1,5 @@
 ﻿{
   "appId": "********",
-  "baseUrl": "https://realm.mongodb.com",
+  "baseUrl": "https://services.cloud.mongodb.com",
   "dataExplorerLink": "https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find"
 }

--- a/sync-todo/v2/client/react-native/README.md
+++ b/sync-todo/v2/client/react-native/README.md
@@ -22,11 +22,11 @@ run this template app.
 Ensure `atlasConfig.json` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose
 **Real Time Sync**, and then follow the prompts. While the backend app is being
 created, you can download this React Native template app pre-configured for your new
 app.

--- a/sync-todo/v2/client/react-native/atlasConfig.json
+++ b/sync-todo/v2/client/react-native/atlasConfig.json
@@ -1,5 +1,5 @@
 {
   "appId": "js-flexible-oseso",
-  "baseUrl": "https://realm.mongodb.com",
+  "baseUrl": "https://services.cloud.mongodb.com",
   "dataExplorerLink": "https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find"
 }

--- a/sync-todo/v2/client/swiftui/App/atlasConfig.plist
+++ b/sync-todo/v2/client/swiftui/App/atlasConfig.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>baseUrl</key>
-	<string>https://realm.mongodb.com</string>
+	<string>https://services.cloud.mongodb.com</string>
 	<key>appId</key>
 	<string>todo-sync-pcmwt</string>
 </dict>

--- a/sync-todo/v2/client/swiftui/README.md
+++ b/sync-todo/v2/client/swiftui/README.md
@@ -12,11 +12,11 @@ This project uses Swift Package Manager (SPM) to load dependencies.
 For this template app to work, you must ensure that `App/atlasConfig.plist` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose 
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose 
 **Real Time Sync**, and then follow the prompts. While the backend app is being 
 created, you can download this SwiftUI template app pre-configured for your new 
 app.

--- a/sync-todo/v2/generated/flutter/README.md
+++ b/sync-todo/v2/generated/flutter/README.md
@@ -10,7 +10,7 @@ run this template app.
 For this template app to work, you must ensure that `/assets/config/atlasConfig.json` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
 - **dataExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
 
 ### Using the Atlas App Services UI

--- a/sync-todo/v2/generated/flutter/README.md
+++ b/sync-todo/v2/generated/flutter/README.md
@@ -11,11 +11,11 @@ For this template app to work, you must ensure that `/assets/config/atlasConfig.
 
 - **appId:** your Atlas App Services App ID.
 - **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
-- **atlasExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
+- **dataExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose
 **Real Time Sync**, and then follow the prompts. While the backend app is being
 created, you can download this Flutter template app pre-configured for your new
 app.
@@ -46,8 +46,8 @@ For this template app to work, you must ensure that
 `/assets/config/atlasConfig.json` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
-- **atlasExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
+- **dataExplorerLink:** the App Services Data Explorer URL. This should be similar to https://cloud.mongodb.com/links/<YOUR-ATLAS-PROJECT-ID>/explorer/<YOUR-CLUSTER-NAME>/database/collection/find
 
 Once you have created the App Services App, replace any value in the
 `appId` field with your App Services App ID. For help finding this ID, refer

--- a/sync-todo/v2/generated/flutter/assets/config/atlasConfig.json
+++ b/sync-todo/v2/generated/flutter/assets/config/atlasConfig.json
@@ -1,4 +1,5 @@
 {
   "appId": "PUT YOUR APP ID HERE",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "dataExplorerLink": "https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find"
 }

--- a/sync-todo/v2/generated/kotlin-sdk/README.md
+++ b/sync-todo/v2/generated/kotlin-sdk/README.md
@@ -5,12 +5,12 @@
 Ensure `app/src/main/res/values/atlasConfig.xml` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
 - **dataExplorerLink:** the link to the Atlas cluster's collections.
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose 
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose 
 **Real Time Sync**, and then follow the prompts. While the backend app is being 
 created, you can download this Kotlin template app pre-configured for your new 
 app.

--- a/sync-todo/v2/generated/kotlin-sdk/app/src/main/res/values/atlasConfig.xml
+++ b/sync-todo/v2/generated/kotlin-sdk/app/src/main/res/values/atlasConfig.xml
@@ -1,4 +1,4 @@
 <resources>
   <string name="realm_app_id">PUT YOUR APP ID HERE</string>
-  <string name="realm_base_url">https://realm.mongodb.com</string>
+  <string name="realm_base_url">https://services.cloud.mongodb.com</string>
 </resources>

--- a/sync-todo/v2/generated/maui/README.md
+++ b/sync-todo/v2/generated/maui/README.md
@@ -12,7 +12,7 @@ The App ID is located in `atlasConfig.json`:
 ```json
 {
   "appId": "********",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com"
 }
 ```
 
@@ -20,7 +20,7 @@ You will need to change the value of `appId` value with your App Services App ID
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose 
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose 
 **Real Time Sync**, and then follow the prompts. While the backend app is being 
 created, you can download this MAUI template app pre-configured for your new 
 app.

--- a/sync-todo/v2/generated/maui/RealmTodo/atlasConfig.json
+++ b/sync-todo/v2/generated/maui/RealmTodo/atlasConfig.json
@@ -1,4 +1,5 @@
 {
   "appId": "PUT YOUR APP ID HERE",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "dataExplorerLink": "https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find"
 }

--- a/sync-todo/v2/generated/react-native/README.md
+++ b/sync-todo/v2/generated/react-native/README.md
@@ -22,11 +22,11 @@ run this template app.
 Ensure `atlasConfig.json` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose
 **Real Time Sync**, and then follow the prompts. While the backend app is being
 created, you can download this React Native template app pre-configured for your new
 app.

--- a/sync-todo/v2/generated/react-native/atlasConfig.json
+++ b/sync-todo/v2/generated/react-native/atlasConfig.json
@@ -1,4 +1,5 @@
 {
   "appId": "PUT YOUR APP ID HERE",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "dataExplorerLink": "https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find"
 }

--- a/sync-todo/v2/generated/swiftui/App/atlasConfig.plist
+++ b/sync-todo/v2/generated/swiftui/App/atlasConfig.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>baseUrl</key>
-	<string>https://realm.mongodb.com</string>
+	<string>https://services.cloud.mongodb.com</string>
 	<key>appId</key>
 	<string>PUT YOUR APP ID HERE</string>
 </dict>

--- a/sync-todo/v2/generated/swiftui/README.md
+++ b/sync-todo/v2/generated/swiftui/README.md
@@ -12,11 +12,11 @@ This project uses Swift Package Manager (SPM) to load dependencies.
 For this template app to work, you must ensure that `App/atlasConfig.plist` exists and contains the following properties:
 
 - **appId:** your Atlas App Services App ID.
-- **baseUrl:** the App Services backend URL. This should be https://realm.mongodb.com in most cases.
+- **baseUrl:** the App Services backend URL. This should be https://services.cloud.mongodb.com in most cases.
 
 ### Using the Atlas App Services UI
 
-The easiest way to use this template app is to log on to [Atlas App Services](https://realm.mongodb.com/) and click the **Create App From Template** button. Choose 
+The easiest way to use this template app is to log on to [Atlas App Services](https://services.cloud.mongodb.com) and click the **Create App From Template** button. Choose 
 **Real Time Sync**, and then follow the prompts. While the backend app is being 
 created, you can download this SwiftUI template app pre-configured for your new 
 app.

--- a/sync-todo/v2/template-atlasConfig.json
+++ b/sync-todo/v2/template-atlasConfig.json
@@ -1,4 +1,5 @@
 {
   "appId": "PUT YOUR APP ID HERE",
-  "baseUrl": "https://realm.mongodb.com"
+  "baseUrl": "https://services.cloud.mongodb.com",
+  "dataExplorerLink": "https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find"
 }

--- a/sync-todo/v2/template-atlasConfig.plist
+++ b/sync-todo/v2/template-atlasConfig.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>baseUrl</key>
-	<string>https://realm.mongodb.com</string>
+	<string>https://services.cloud.mongodb.com</string>
 	<key>appId</key>
 	<string>PUT YOUR APP ID HERE</string>
 </dict>

--- a/sync-todo/v2/template-atlasConfig.xml
+++ b/sync-todo/v2/template-atlasConfig.xml
@@ -1,4 +1,4 @@
 <resources>
   <string name="realm_app_id">PUT YOUR APP ID HERE</string>
-  <string name="realm_base_url">https://realm.mongodb.com</string>
+  <string name="realm_base_url">https://services.cloud.mongodb.com</string>
 </resources>


### PR DESCRIPTION
This PR primarily updates the baseURL per this Jira ticket: https://jira.mongodb.org/browse/DOCSP-35276

But while I was touching the `atlasConfig` files, I fixed a few remaining potential issues related to missing `dataExplorerLink` URLs for these tickets:

- https://jira.mongodb.org/browse/DOCSP-33472
- https://jira.mongodb.org/browse/DOCSP-34798

Note for reviewer: the failing Run web-js tests checks are expected as I have not set up an API key to run those tests.