### PR TITLE
Fix missing data explorer link in Kotlin

### DIFF
--- a/sync-todo/v2/generated/kotlin-sdk/app/src/main/res/values/atlasConfig.xml
+++ b/sync-todo/v2/generated/kotlin-sdk/app/src/main/res/values/atlasConfig.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="realm_app_id">PUT YOUR APP ID HERE</string>
   <string name="realm_base_url">https://services.cloud.mongodb.com</string>
+  <string name="realm_data_explorer_link">https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find</string>
 </resources>

--- a/sync-todo/v2/template-atlasConfig.xml
+++ b/sync-todo/v2/template-atlasConfig.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="realm_app_id">PUT YOUR APP ID HERE</string>
   <string name="realm_base_url">https://services.cloud.mongodb.com</string>
+  <string name="realm_data_explorer_link">https://cloud.mongodb.com/links/app_id/explorer/cluster_name/database/collection/find</string>
 </resources>


### PR DESCRIPTION
My fix in #182 didn't fix the missing data explorer link in Kotlin. I didn't realize that the bluehawk script was replacing the contents of the client's `atlasConfig.xml` with a sanitized version, so the change I made in the client file was being overwritten by the sanitized one without that field.

This PR updates the sanitized version and the generated app's `atlasConfig.xml`.