### PR TITLE
Edge Server: Add and update details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A GitHub Action creates "artifact repos" of a few subdirectories so that the cli
 - https://github.com/mongodb/template-app-maui-todo
 - https://github.com/mongodb/template-app-react-native-todo
 - https://github.com/mongodb/template-app-swiftui-todo
+- https://github.com/mongodb/template-app-edge-server
 
 ## Adding a New Template App
 

--- a/other/edge-server/client/README.md
+++ b/other/edge-server/client/README.md
@@ -365,6 +365,50 @@ This can indicate two possible issues:
 
 Confirm that both servers are running and try again.
 
+#### My new Item added in Atlas doesn't show up in the React client
+
+When you add a new `Item` in Atlas, it doesn't show up automatically in
+the React client. The client does not have a listener observing changes
+to the collection. You can manually reload the React client to view the
+new `Item`.
+
+If you reload the React client and it still doesn't show the new `Item`, 
+check:
+
+- The Edge Server is running
+- The Node.js Express server is running
+- The schema of the `Item` you added in Atlas matches the App Services Schema
+  for the Edge Server App, with required fields of the appropriate types:
+
+```json
+{
+  "title": "Item",
+  "properties": {
+    "_id": {
+      "bsonType": "objectId"
+    },
+    "isComplete": {
+      "bsonType": "bool"
+    },
+    "summary": {
+      "bsonType": "string"
+    }
+  },
+  "required": [
+    "_id",
+    "isComplete",
+    "summary"
+  ]
+}
+```
+
+If you've confirmed these details and you still don't see the new `Item`
+that you added in Atlas reflected in the React client, check the App Services
+logs and Edge Server for error messages.
+
+For information about how to check the App Services logs, refer to 
+[View Application Logs](https://www.mongodb.com/docs/atlas/app-services/activity/view-logs/)
+
 ## Issues
 
 Please report issues with the template at: https://github.com/mongodb-university/realm-template-apps/issues/new

--- a/other/edge-server/client/README.md
+++ b/other/edge-server/client/README.md
@@ -22,6 +22,13 @@ directly to Edge Server without authorization.
 For a MERN stack tutorial, refer to 
 [How to Use Mern Stack: A Complete Guide](https://www.mongodb.com/languages/mern-stack-tutorial).
 
+For more information about Edge Server, refer to the 
+[Edge Server documentation](https://www.mongodb.com/docs/atlas/app-services/edge-server/).
+
+Atlas Edge Server is currently in Private Preview. To learn more about
+previewing Edge Server, refer to the product page at
+[Edge Server](https://www.mongodb.com/products/platform/atlas-edge-server).
+
 ## Create an App Services App
 
 Edge Server connects to Atlas through an App Services App backend. 
@@ -87,9 +94,10 @@ blob that includes the generated `client_app_id` similar to:
 ```shell
 {
   "client_app_id": "edgeserverapp-abc123",
-  "filepath": "/current_path/edgeserverapp",
+  "filepath": "/current_path/EdgeServerApp",
   "url": "https://realm.mongodb.com/groups/1234567890abcdefghijk/apps/1234567890abcdefghijk/dashboard",
   "backend": "/current_path/edgeserverapp/backend",
+  "frontends": "/Users/dachary.carey/temp/EdgeServerApp/frontend",
   "clusters": [
     {
       "name": "mongodb-atlas"
@@ -102,6 +110,15 @@ You now have an App Services App with a configured backend and an App Services
 App ID. 
 
 > **NOTE:** The `client_app_id` is your App Services App ID. You will need it later steps. 
+
+While Edge Server is in Private Preview, the `frontends` directory listed in
+the blob does not apply to this template. You can only get the Edge Server
+client from this GitHub repository: https://github.com/mongodb/template-app-edge-server/
+
+Additionally, the "View directions on how to run the template app:" text does
+not contain information about running the Edge Server template. You can view
+the Edge Server client README - this document you're currently viewing - for 
+those details.
 
 ## Enable Edge Server for your App 
 
@@ -295,7 +312,8 @@ and/or port in your `.env` file.
 
 ## Install dependencies and start the React server
 
-With the Edge Server running, cd into the `react-client` directory.
+With the Edge Server and the Express server running, cd into the `react-client` 
+directory.
 
 Install the required dependencies:
 
@@ -346,3 +364,7 @@ This can indicate two possible issues:
 - Edge Server isn't running
 
 Confirm that both servers are running and try again.
+
+## Issues
+
+Please report issues with the template at: https://github.com/mongodb-university/realm-template-apps/issues/new


### PR DESCRIPTION
Add a few documentation links and README tweaks based on testing the Edge Server template.

When we merge this PR, it should trigger a new push to the artifact repo, remove the `backend` directory, and display this README as the root of the artifact repo.