### PR TITLE
DOCSP-36923: Bump Kotlin app to v1.13.0

### DIFF
--- a/sync-todo/v2/client/kotlin-sdk/app/build.gradle.kts
+++ b/sync-todo/v2/client/kotlin-sdk/app/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
     id("com.android.application")
     kotlin("android")
-    id("io.realm.kotlin") version "1.8.0"
+    id("io.realm.kotlin") version "1.13.0"
 }
 
 android {
     compileSdk = 33
     defaultConfig {
-        applicationId = "com.mongodb.app"
+        namespace = "com.mongodb.app"
         minSdk = 28
         targetSdk = 33
         versionCode = 1
@@ -22,7 +22,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2"
+        kotlinCompilerExtensionVersion = "1.5.4"
     }
 }
 
@@ -42,6 +42,6 @@ dependencies {
     implementation("com.google.android.material:material:1.7.0")
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    implementation("io.realm.kotlin:library-sync:1.8.0") // DON'T FORGET TO UPDATE VERSION IN PROJECT GRADLE
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0")
+    implementation("io.realm.kotlin:library-sync:1.13.0") // DON'T FORGET TO UPDATE VERSION IN PROJECT GRADLE
 }

--- a/sync-todo/v2/client/kotlin-sdk/build.gradle.kts
+++ b/sync-todo/v2/client/kotlin-sdk/build.gradle.kts
@@ -5,8 +5,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     }
 }
 

--- a/sync-todo/v2/client/kotlin-sdk/gradle/wrapper/gradle-wrapper.properties
+++ b/sync-todo/v2/client/kotlin-sdk/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 31 14:55:56 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/sync-todo/v2/generated/kotlin-sdk/app/build.gradle.kts
+++ b/sync-todo/v2/generated/kotlin-sdk/app/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
     id("com.android.application")
     kotlin("android")
-    id("io.realm.kotlin") version "1.8.0"
+    id("io.realm.kotlin") version "1.13.0"
 }
 
 android {
     compileSdk = 33
     defaultConfig {
-        applicationId = "com.mongodb.app"
+        namespace = "com.mongodb.app"
         minSdk = 28
         targetSdk = 33
         versionCode = 1
@@ -22,7 +22,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2"
+        kotlinCompilerExtensionVersion = "1.5.4"
     }
 }
 
@@ -42,6 +42,6 @@ dependencies {
     implementation("com.google.android.material:material:1.7.0")
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    implementation("io.realm.kotlin:library-sync:1.8.0") // DON'T FORGET TO UPDATE VERSION IN PROJECT GRADLE
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0")
+    implementation("io.realm.kotlin:library-sync:1.13.0") // DON'T FORGET TO UPDATE VERSION IN PROJECT GRADLE
 }

--- a/sync-todo/v2/generated/kotlin-sdk/build.gradle.kts
+++ b/sync-todo/v2/generated/kotlin-sdk/build.gradle.kts
@@ -5,8 +5,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     }
 }
 

--- a/sync-todo/v2/generated/kotlin-sdk/gradle/wrapper/gradle-wrapper.properties
+++ b/sync-todo/v2/generated/kotlin-sdk/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 31 14:55:56 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update Kotlin template app from v1.8.0 to v1.13.0 and update any dependencies 