### PR TITLE
Use exact Swift version 10.49.3 to avoid breaking changes

### DIFF
--- a/sync-todo/v2/client/swiftui/App.xcodeproj/project.pbxproj
+++ b/sync-todo/v2/client/swiftui/App.xcodeproj/project.pbxproj
@@ -431,8 +431,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 10.50.0;
+				kind = exactVersion;
+				version = 10.49.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/sync-todo/v2/generated/swiftui/App.xcodeproj/project.pbxproj
+++ b/sync-todo/v2/generated/swiftui/App.xcodeproj/project.pbxproj
@@ -431,8 +431,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 10.50.0;
+				kind = exactVersion;
+				version = 10.49.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
After merging and testing #204, I found that 10.50.0 introduces a breaking change to initial subscriptions that causes the template app to crash.

While waiting for info from engineering, I'm downgrading the template app to only use v10.49.3 instead of using next major to avoid users encountering this issue.