### PR TITLE
C++ Template App Follow-Ups

### DIFF
--- a/sync-todo/v2/client/cpp/CMakeLists.txt
+++ b/sync-todo/v2/client/cpp/CMakeLists.txt
@@ -8,7 +8,7 @@ Include(FetchContent)
 
 FetchContent_Declare(cpprealm
         GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-        GIT_TAG        v1.0.0
+        GIT_TAG        v1.1.1
 )
 
 FetchContent_Declare(ftxui

--- a/sync-todo/v2/client/cpp/README.md
+++ b/sync-todo/v2/client/cpp/README.md
@@ -83,6 +83,13 @@ This app uses CMake to manage dependencies. You must have CMake installed to use
 
 Please report issues with the template at https://github.com/mongodb-university/realm-template-apps/issues/new
 
+### Known Issues
+
+If the error modal displays, and you move your mouse over the item  list in the terminal prior to dismissing the error 
+modal, the UI rendering breaks. This is related to limitations with the FTXUI library. If this occurs, quit the app 
+using `ctrl + c`, and re-run it. You can avoid this issue by using the enter key to press the `Dismiss` button in the
+error modal before moving the mouse.
+
 ## Structure
 
 To see the code examples concerned with Atlas Device SDK for C++, these files are the most relevant:

--- a/sync-todo/v2/client/cpp/README.md
+++ b/sync-todo/v2/client/cpp/README.md
@@ -1,8 +1,5 @@
 # C++ Template App
 
-> [!NOTE]  
-> This is a Preview release of the C++ template app.
-
 A todo list application built with the [Atlas Device SDK for C++](https://www.mongodb.com/docs/realm/sdk/cpp/) and [Atlas Device Sync](https://www.mongodb.com/docs/atlas/app-services/sync/).
 
 This app uses a terminal UI built with [FTXUI](https://github.com/ArthurSonzogni/FTXUI).

--- a/sync-todo/v2/client/cpp/atlasConfig.json
+++ b/sync-todo/v2/client/cpp/atlasConfig.json
@@ -1,6 +1,6 @@
 {
-  "appId": "INSERT-YOUR-APP-ID-HERE",
-  "appUrl": "https://services.cloud.mongodb.com/groups/6388cb218e4d865c34158da5/apps/65f46bd16a5a245b65769e5d",
+  "appId": "cpp-template-tester-otnlf",
+  "appUrl": "https://services.cloud.mongodb.com/groups/6388cb218e4d865c34158da5/apps/661696804e6a1465f66197ef",
   "baseUrl": "https://services.cloud.mongodb.com",
   "clientApiBaseUrl": "https://us-east-1.aws.services.cloud.mongodb.com",
   "dataApiBaseUrl": "https://us-east-1.aws.data.mongodb-api.com",

--- a/sync-todo/v2/client/cpp/controllers/app_controller.cpp
+++ b/sync-todo/v2/client/cpp/controllers/app_controller.cpp
@@ -17,9 +17,7 @@ AppController::AppController(ftxui::ScreenInteractive *screen, std::string const
       .app_id = appConfigMetadata.appId
   };
   _appState.app = std::make_unique<realm::App>(appConfig);
-  _appState.authManager = std::make_unique<AuthManager>(this, _appState.app.get());
   _appState.errorManager = std::make_unique<ErrorManager>(this);
-  _appState.appConfigMetadata = appConfigMetadata;
 
   // Lay out and style the error modal.
   auto dismissButton = ftxui::Button("Dismiss", [this]{ _appState.errorManager->clearError(); });
@@ -27,14 +25,17 @@ AppController::AppController(ftxui::ScreenInteractive *screen, std::string const
 
   _errorModal = Renderer(buttonLayout, [=] {
     auto content = ftxui::vbox({
-      ftxui::hbox(ftxui::text(_appState.errorManager->getError().value()) | ftxui::hcenter),
-      ftxui::hbox(dismissButton->Render()) | ftxui::hcenter
-    }) | ftxui::center | size(ftxui::HEIGHT, ftxui::GREATER_THAN, 10);
+                                   ftxui::hbox(ftxui::paragraph(_appState.errorManager->getError().value()) | ftxui::hcenter),
+                                   ftxui::hbox(dismissButton->Render()) | ftxui::hcenter
+                               }) | ftxui::center | size(ftxui::HEIGHT, ftxui::GREATER_THAN, 10);
     return window(
         ftxui::text(L" Error "), content) | ftxui::clear_under | ftxui::center | size(ftxui::WIDTH, ftxui::GREATER_THAN, 80);
   });
 
   component()->Add(_navigation.component());
+
+  _appState.authManager = std::make_unique<AuthManager>(this, _appState.app.get(), _appState.errorManager.get());
+  _appState.appConfigMetadata = appConfigMetadata;
 
   if (_appState.app->get_current_user()) {
     _navigation.goTo(std::make_unique<HomeController>(&_appState));

--- a/sync-todo/v2/client/cpp/controllers/home_controller.cpp
+++ b/sync-todo/v2/client/cpp/controllers/home_controller.cpp
@@ -91,7 +91,7 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
     ftxui::Elements tasks;
     // If the user has toggled the checkbox to hide completed tasks, show only the incomplete task list.
     // Otherwise, show all items.
-    for (auto const item: itemList) {
+    for (auto const &item: itemList) {
       std::string completionString = (item.isComplete) ? " Complete " : " Incomplete ";
       std::string mineOrNot = (item.owner_id == userId) ? "   Mine " : " Theirs ";
       auto taskRow = ftxui::hbox({

--- a/sync-todo/v2/client/cpp/controllers/home_controller.cpp
+++ b/sync-todo/v2/client/cpp/controllers/home_controller.cpp
@@ -91,7 +91,7 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
     ftxui::Elements tasks;
     // If the user has toggled the checkbox to hide completed tasks, show only the incomplete task list.
     // Otherwise, show all items.
-    for (auto &item: itemList) {
+    for (auto const item: itemList) {
       std::string completionString = (item.isComplete) ? " Complete " : " Incomplete ";
       std::string mineOrNot = (item.owner_id == userId) ? "   Mine " : " Theirs ";
       auto taskRow = ftxui::hbox({

--- a/sync-todo/v2/client/cpp/controllers/home_controller.cpp
+++ b/sync-todo/v2/client/cpp/controllers/home_controller.cpp
@@ -59,7 +59,8 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
 
   auto homeControllerButtonView = Renderer(optionsLayout, [=] {
     return vbox(
-        hbox(toggleOfflineModeButton->Render(),
+        hbox(
+             toggleOfflineModeButton->Render() | size(ftxui::HEIGHT, ftxui::EQUAL, 10),
              ftxui::separator(),
              toggleSubscriptionsButton->Render(),
              ftxui::separator(),
@@ -67,7 +68,7 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
              logoutButton->Render(),
              ftxui::separator(),
              quitButton->Render()
-             ) | ftxui::border | ftxui::center | size(ftxui::WIDTH, ftxui::GREATER_THAN, 100)) ;
+             ) | ftxui::border | ftxui::center | size(ftxui::WIDTH, ftxui::EQUAL, 100)) ;
   });
 
   // Accept user inputs and create new items in the database.

--- a/sync-todo/v2/client/cpp/controllers/home_controller.cpp
+++ b/sync-todo/v2/client/cpp/controllers/home_controller.cpp
@@ -12,7 +12,7 @@ ftxui::Component VWrap(const std::string& name, const ftxui::Component& componen
 }
 
 HomeController::HomeController(AppState *appState): Controller(ftxui::Container::Vertical({})), _appState(appState),
-                                                    _dbManager(_appState, &_homeControllerState) {
+                                                    _dbManager(this, _appState) {
   auto user = _appState->app->get_current_user();
   auto userId = user->identifier();
 
@@ -191,4 +191,28 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
 void HomeController::onFrame() {
   // Refresh the database to show new items that have synced in the background.
   _dbManager.refreshDatabase();
+}
+
+void HomeController::onSyncSessionPaused() {
+  _homeControllerState.offlineModeSelection = OfflineModeSelection::offlineModeEnabled;
+  _homeControllerState.offlineModeLabel = "Go Online";
+}
+
+void HomeController::onSyncSessionResumed() {
+  _homeControllerState.offlineModeSelection = OfflineModeSelection::offlineModeDisabled;
+  _homeControllerState.offlineModeLabel = "Go Offline";
+}
+
+void HomeController::onSubscriptionSelectionMyItems() {
+  _homeControllerState.subscriptionSelection = SubscriptionSelection::myItems;
+  _homeControllerState.subscriptionSelectionLabel = "Switch to All";
+}
+
+void HomeController::onSubscriptionSelectionAllItems() {
+  _homeControllerState.subscriptionSelection = SubscriptionSelection::allItems;
+  _homeControllerState.subscriptionSelectionLabel = "Switch to Mine";
+}
+
+SubscriptionSelection HomeController::getSubscriptionSelection() {
+  return _homeControllerState.subscriptionSelection;
 }

--- a/sync-todo/v2/client/cpp/controllers/home_controller.hpp
+++ b/sync-todo/v2/client/cpp/controllers/home_controller.hpp
@@ -9,16 +9,23 @@
 #include "../views/scroller.hpp"
 #include "../ss.hpp"
 
-class HomeController final : public Controller {
+class HomeController final : public Controller, public DatabaseManager::Delegate {
+ public:
+
+  explicit HomeController(AppState *appState);
+
+  void onFrame() override;
+
  private:
   AppState *_appState{nullptr};
   HomeControllerState _homeControllerState;
   DatabaseManager _dbManager;
 
- public:
-  explicit HomeController(AppState *appState);
-
-  void onFrame() override;
+  void onSyncSessionPaused() override;
+  void onSyncSessionResumed() override;
+  void onSubscriptionSelectionMyItems() override;
+  void onSubscriptionSelectionAllItems() override;
+  SubscriptionSelection getSubscriptionSelection() override;
 };
 
 #endif

--- a/sync-todo/v2/client/cpp/managers/auth_manager.cpp
+++ b/sync-todo/v2/client/cpp/managers/auth_manager.cpp
@@ -1,21 +1,36 @@
 #include "auth_manager.hpp"
 
-AuthManager::AuthManager(Delegate *delegate, realm::App *app): _delegate(delegate), _app(app) {  }
+AuthManager::AuthManager(Delegate *delegate, realm::App *app, ErrorManager *errorManager): _delegate(delegate), _app(app), _errorManager(errorManager) {  }
 
 void AuthManager::registerUser(std::string const& userEmail, std::string const& userPassword) {
-  _app->register_user(userEmail, userPassword).get();
-  logIn(userEmail, userPassword);
+  try {
+    _app->register_user(userEmail, userPassword).get();
+    logIn(userEmail, userPassword);
+  } catch(realm::app_error const &error) {
+    auto errorText = SS("An error occurred while registering a user. Message: " << error.message() << std::endl);
+    _errorManager->setError(errorText);
+  }
 }
 
 void AuthManager::logIn(std::string const& userEmail, std::string const& userPassword) {
-  _app->login(
-          realm::App::credentials::username_password(userEmail, userPassword))
-      .get();
-  _delegate->onLoggedIn();
+  try {
+    _app->login(
+            realm::App::credentials::username_password(userEmail, userPassword))
+        .get();
+    _delegate->onLoggedIn();
+  } catch(realm::app_error const &error) {
+    auto errorText = SS("An error occurred while logging in. Message: " << error.message() << std::endl);
+    _errorManager->setError(errorText);
+  }
 }
 
 void AuthManager::logOut() {
-  auto currentUser = _app->get_current_user();
-  currentUser->log_out().get();
-  _delegate->onLoggedOut();
+  try {
+    auto currentUser = _app->get_current_user();
+    currentUser->log_out().get();
+    _delegate->onLoggedOut();
+  } catch(realm::app_error const &error) {
+    auto errorText = SS("An app error occurred. Message: " << error.message() << std::endl);
+    _errorManager->setError(errorText);
+  }
 }

--- a/sync-todo/v2/client/cpp/managers/auth_manager.hpp
+++ b/sync-todo/v2/client/cpp/managers/auth_manager.hpp
@@ -2,6 +2,8 @@
 #define AUTH_MANAGER_HPP
 
 #include <cpprealm/sdk.hpp>
+#include "../managers/error_manager.hpp"
+#include "../ss.hpp"
 
 class AuthManager {
  public:
@@ -11,7 +13,7 @@ class AuthManager {
     virtual void onLoggedOut() = 0;
   };
 
-  explicit AuthManager(Delegate *delegate, realm::App *app);
+  explicit AuthManager(Delegate *delegate, realm::App *app, ErrorManager *errorManager);
 
   void registerUser(std::string const& userEmail, std::string const& userPassword);
 
@@ -22,6 +24,7 @@ class AuthManager {
  private:
   Delegate *_delegate{nullptr};
   realm::App *_app{nullptr};
+  ErrorManager *_errorManager{nullptr};
 };
 
 #endif

--- a/sync-todo/v2/client/cpp/managers/database_manager.cpp
+++ b/sync-todo/v2/client/cpp/managers/database_manager.cpp
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-DatabaseManager::DatabaseManager(AppState *appState, HomeControllerState *homeControllerState): _appState(appState), _homeControllerState(homeControllerState) {
+DatabaseManager::DatabaseManager(Delegate *delegate, AppState *appState): _delegate(delegate), _appState(appState) {
   auto user = _appState->app->get_current_user();
 
   // Sync configuration and sync subscription management.
@@ -75,12 +75,10 @@ void DatabaseManager::toggleOfflineMode() {
   auto syncSession = _database->get_sync_session();
   if (syncSession->state() == realm::internal::bridge::sync_session::state::paused) {
     syncSession->resume();
-    _homeControllerState->offlineModeSelection = OfflineModeSelection::offlineModeDisabled;
-    _homeControllerState->offlineModeLabel = "Go Offline";
+    _delegate->onSyncSessionResumed();
   } else if (syncSession->state() == realm::internal::bridge::sync_session::state::active) {
     syncSession->pause();
-    _homeControllerState->offlineModeSelection = OfflineModeSelection::offlineModeEnabled;
-    _homeControllerState->offlineModeLabel = "Go Online";
+    _delegate->onSyncSessionPaused();
   }
 }
 
@@ -93,7 +91,7 @@ void DatabaseManager::toggleSubscriptions() {
   }
   // Note the subscription state at the start of the toggle operation.
   // We'll change it after updating the subscriptions.
-  auto currentSubscriptionState = _homeControllerState->subscriptionSelection;
+  auto currentSubscriptionState = _delegate->getSubscriptionSelection();
 
   _database->subscriptions().update([&](realm::mutable_sync_subscription_set& subs) {
     // If the currentSubscriptionState is `allItems`, toggling it should show only my items.
@@ -108,8 +106,7 @@ void DatabaseManager::toggleSubscriptions() {
                               });
       }
       // Update the subscription selection to reflect the new subscription.
-      _homeControllerState->subscriptionSelection = SubscriptionSelection::myItems;
-      _homeControllerState->subscriptionSelectionLabel = "Switch to All";
+      _delegate->onSubscriptionSelectionMyItems();
 
       // If the currentSubscriptionState is `myItems`, toggling should show all items.
       // Remove the `myItems` subscription and make sure the subscription for the all items is present.
@@ -122,8 +119,7 @@ void DatabaseManager::toggleSubscriptions() {
       }
 
       // Update the subscription selection to reflect the new subscription.
-      _homeControllerState->subscriptionSelection = SubscriptionSelection::allItems;
-      _homeControllerState->subscriptionSelectionLabel = "Switch to Mine";
+      _delegate->onSubscriptionSelectionAllItems();
     }
   }).get();
 

--- a/sync-todo/v2/client/cpp/managers/database_manager.cpp
+++ b/sync-todo/v2/client/cpp/managers/database_manager.cpp
@@ -130,8 +130,8 @@ void DatabaseManager::toggleSubscriptions() {
 /** Get a list of all items in the database. Sort it to show the most recent items on top. */
 realm::results<realm::Item> DatabaseManager::getItemList() {
   auto items = _database->objects<realm::Item>();
-  items.sort("_id", false);
-  return items;
+  auto sortedItems = items.sort("_id", false);
+  return sortedItems;
 }
 
 /** Get a list of items in the database, filtered to hide completed items. */
@@ -139,6 +139,6 @@ realm::results<realm::Item> DatabaseManager::getIncompleteItemList() {
   auto items = _database->objects<realm::Item>();
   auto incompleteItems = items.where(
       [](auto const &item) { return item.isComplete == false; });
-  incompleteItems.sort("_id", false);
-  return incompleteItems;
+  auto sortedIncompleteItems = incompleteItems.sort("_id", false);
+  return sortedIncompleteItems;
 }

--- a/sync-todo/v2/client/cpp/managers/database_manager.hpp
+++ b/sync-todo/v2/client/cpp/managers/database_manager.hpp
@@ -10,7 +10,16 @@
 
 class DatabaseManager {
  public:
-  DatabaseManager(AppState *appState, HomeControllerState *homeControllerState);
+  struct Delegate {
+    virtual ~Delegate() = default;
+    virtual void onSyncSessionPaused() = 0;
+    virtual void onSyncSessionResumed() = 0;
+    virtual void onSubscriptionSelectionMyItems() = 0;
+    virtual void onSubscriptionSelectionAllItems() = 0;
+    virtual SubscriptionSelection getSubscriptionSelection() = 0;
+  };
+
+  DatabaseManager(Delegate *delegate, AppState *appState);
 
   void addNew(bool newItemIsComplete, std::string newItemSummary);
   void remove(realm::managed<realm::Item> itemToDelete);
@@ -22,12 +31,12 @@ class DatabaseManager {
   realm::results<realm::Item> getIncompleteItemList();
 
  private:
+  Delegate *_delegate{nullptr};
   std::string _allItemSubscriptionName;
   std::string _myItemSubscriptionName;
   std::unique_ptr<realm::db> _database;
   std::string _userId;
   AppState *_appState;
-  HomeControllerState *_homeControllerState;
 };
 
 #endif

--- a/sync-todo/v2/generated/cpp/CMakeLists.txt
+++ b/sync-todo/v2/generated/cpp/CMakeLists.txt
@@ -8,7 +8,7 @@ Include(FetchContent)
 
 FetchContent_Declare(cpprealm
         GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-        GIT_TAG        v1.0.0
+        GIT_TAG        v1.1.1
 )
 
 FetchContent_Declare(ftxui

--- a/sync-todo/v2/generated/cpp/README.md
+++ b/sync-todo/v2/generated/cpp/README.md
@@ -83,6 +83,13 @@ This app uses CMake to manage dependencies. You must have CMake installed to use
 
 Please report issues with the template at https://github.com/mongodb-university/realm-template-apps/issues/new
 
+### Known Issues
+
+If the error modal displays, and you move your mouse over the item  list in the terminal prior to dismissing the error 
+modal, the UI rendering breaks. This is related to limitations with the FTXUI library. If this occurs, quit the app 
+using `ctrl + c`, and re-run it. You can avoid this issue by using the enter key to press the `Dismiss` button in the
+error modal before moving the mouse.
+
 ## Structure
 
 To see the code examples concerned with Atlas Device SDK for C++, these files are the most relevant:

--- a/sync-todo/v2/generated/cpp/README.md
+++ b/sync-todo/v2/generated/cpp/README.md
@@ -1,8 +1,5 @@
 # C++ Template App
 
-> [!NOTE]  
-> This is a Preview release of the C++ template app.
-
 A todo list application built with the [Atlas Device SDK for C++](https://www.mongodb.com/docs/realm/sdk/cpp/) and [Atlas Device Sync](https://www.mongodb.com/docs/atlas/app-services/sync/).
 
 This app uses a terminal UI built with [FTXUI](https://github.com/ArthurSonzogni/FTXUI).

--- a/sync-todo/v2/generated/cpp/controllers/app_controller.cpp
+++ b/sync-todo/v2/generated/cpp/controllers/app_controller.cpp
@@ -17,9 +17,7 @@ AppController::AppController(ftxui::ScreenInteractive *screen, std::string const
       .app_id = appConfigMetadata.appId
   };
   _appState.app = std::make_unique<realm::App>(appConfig);
-  _appState.authManager = std::make_unique<AuthManager>(this, _appState.app.get());
   _appState.errorManager = std::make_unique<ErrorManager>(this);
-  _appState.appConfigMetadata = appConfigMetadata;
 
   // Lay out and style the error modal.
   auto dismissButton = ftxui::Button("Dismiss", [this]{ _appState.errorManager->clearError(); });
@@ -27,14 +25,17 @@ AppController::AppController(ftxui::ScreenInteractive *screen, std::string const
 
   _errorModal = Renderer(buttonLayout, [=] {
     auto content = ftxui::vbox({
-      ftxui::hbox(ftxui::text(_appState.errorManager->getError().value()) | ftxui::hcenter),
-      ftxui::hbox(dismissButton->Render()) | ftxui::hcenter
-    }) | ftxui::center | size(ftxui::HEIGHT, ftxui::GREATER_THAN, 10);
+                                   ftxui::hbox(ftxui::paragraph(_appState.errorManager->getError().value()) | ftxui::hcenter),
+                                   ftxui::hbox(dismissButton->Render()) | ftxui::hcenter
+                               }) | ftxui::center | size(ftxui::HEIGHT, ftxui::GREATER_THAN, 10);
     return window(
         ftxui::text(L" Error "), content) | ftxui::clear_under | ftxui::center | size(ftxui::WIDTH, ftxui::GREATER_THAN, 80);
   });
 
   component()->Add(_navigation.component());
+
+  _appState.authManager = std::make_unique<AuthManager>(this, _appState.app.get(), _appState.errorManager.get());
+  _appState.appConfigMetadata = appConfigMetadata;
 
   if (_appState.app->get_current_user()) {
     _navigation.goTo(std::make_unique<HomeController>(&_appState));

--- a/sync-todo/v2/generated/cpp/controllers/home_controller.cpp
+++ b/sync-todo/v2/generated/cpp/controllers/home_controller.cpp
@@ -91,7 +91,7 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
     ftxui::Elements tasks;
     // If the user has toggled the checkbox to hide completed tasks, show only the incomplete task list.
     // Otherwise, show all items.
-    for (auto const item: itemList) {
+    for (auto const &item: itemList) {
       std::string completionString = (item.isComplete) ? " Complete " : " Incomplete ";
       std::string mineOrNot = (item.owner_id == userId) ? "   Mine " : " Theirs ";
       auto taskRow = ftxui::hbox({

--- a/sync-todo/v2/generated/cpp/controllers/home_controller.cpp
+++ b/sync-todo/v2/generated/cpp/controllers/home_controller.cpp
@@ -91,7 +91,7 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
     ftxui::Elements tasks;
     // If the user has toggled the checkbox to hide completed tasks, show only the incomplete task list.
     // Otherwise, show all items.
-    for (auto &item: itemList) {
+    for (auto const item: itemList) {
       std::string completionString = (item.isComplete) ? " Complete " : " Incomplete ";
       std::string mineOrNot = (item.owner_id == userId) ? "   Mine " : " Theirs ";
       auto taskRow = ftxui::hbox({

--- a/sync-todo/v2/generated/cpp/controllers/home_controller.cpp
+++ b/sync-todo/v2/generated/cpp/controllers/home_controller.cpp
@@ -12,7 +12,7 @@ ftxui::Component VWrap(const std::string& name, const ftxui::Component& componen
 }
 
 HomeController::HomeController(AppState *appState): Controller(ftxui::Container::Vertical({})), _appState(appState),
-                                                    _dbManager(_appState, &_homeControllerState) {
+                                                    _dbManager(this, _appState) {
   auto user = _appState->app->get_current_user();
   auto userId = user->identifier();
 
@@ -59,7 +59,8 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
 
   auto homeControllerButtonView = Renderer(optionsLayout, [=] {
     return vbox(
-        hbox(toggleOfflineModeButton->Render(),
+        hbox(
+             toggleOfflineModeButton->Render() | size(ftxui::HEIGHT, ftxui::EQUAL, 10),
              ftxui::separator(),
              toggleSubscriptionsButton->Render(),
              ftxui::separator(),
@@ -67,7 +68,7 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
              logoutButton->Render(),
              ftxui::separator(),
              quitButton->Render()
-             ) | ftxui::border | ftxui::center | size(ftxui::WIDTH, ftxui::GREATER_THAN, 100)) ;
+             ) | ftxui::border | ftxui::center | size(ftxui::WIDTH, ftxui::EQUAL, 100)) ;
   });
 
   // Accept user inputs and create new items in the database.
@@ -190,4 +191,28 @@ HomeController::HomeController(AppState *appState): Controller(ftxui::Container:
 void HomeController::onFrame() {
   // Refresh the database to show new items that have synced in the background.
   _dbManager.refreshDatabase();
+}
+
+void HomeController::onSyncSessionPaused() {
+  _homeControllerState.offlineModeSelection = OfflineModeSelection::offlineModeEnabled;
+  _homeControllerState.offlineModeLabel = "Go Online";
+}
+
+void HomeController::onSyncSessionResumed() {
+  _homeControllerState.offlineModeSelection = OfflineModeSelection::offlineModeDisabled;
+  _homeControllerState.offlineModeLabel = "Go Offline";
+}
+
+void HomeController::onSubscriptionSelectionMyItems() {
+  _homeControllerState.subscriptionSelection = SubscriptionSelection::myItems;
+  _homeControllerState.subscriptionSelectionLabel = "Switch to All";
+}
+
+void HomeController::onSubscriptionSelectionAllItems() {
+  _homeControllerState.subscriptionSelection = SubscriptionSelection::allItems;
+  _homeControllerState.subscriptionSelectionLabel = "Switch to Mine";
+}
+
+SubscriptionSelection HomeController::getSubscriptionSelection() {
+  return _homeControllerState.subscriptionSelection;
 }

--- a/sync-todo/v2/generated/cpp/controllers/home_controller.hpp
+++ b/sync-todo/v2/generated/cpp/controllers/home_controller.hpp
@@ -9,16 +9,23 @@
 #include "../views/scroller.hpp"
 #include "../ss.hpp"
 
-class HomeController final : public Controller {
+class HomeController final : public Controller, public DatabaseManager::Delegate {
+ public:
+
+  explicit HomeController(AppState *appState);
+
+  void onFrame() override;
+
  private:
   AppState *_appState{nullptr};
   HomeControllerState _homeControllerState;
   DatabaseManager _dbManager;
 
- public:
-  explicit HomeController(AppState *appState);
-
-  void onFrame() override;
+  void onSyncSessionPaused() override;
+  void onSyncSessionResumed() override;
+  void onSubscriptionSelectionMyItems() override;
+  void onSubscriptionSelectionAllItems() override;
+  SubscriptionSelection getSubscriptionSelection() override;
 };
 
 #endif

--- a/sync-todo/v2/generated/cpp/managers/auth_manager.cpp
+++ b/sync-todo/v2/generated/cpp/managers/auth_manager.cpp
@@ -1,21 +1,36 @@
 #include "auth_manager.hpp"
 
-AuthManager::AuthManager(Delegate *delegate, realm::App *app): _delegate(delegate), _app(app) {  }
+AuthManager::AuthManager(Delegate *delegate, realm::App *app, ErrorManager *errorManager): _delegate(delegate), _app(app), _errorManager(errorManager) {  }
 
 void AuthManager::registerUser(std::string const& userEmail, std::string const& userPassword) {
-  _app->register_user(userEmail, userPassword).get();
-  logIn(userEmail, userPassword);
+  try {
+    _app->register_user(userEmail, userPassword).get();
+    logIn(userEmail, userPassword);
+  } catch(realm::app_error const &error) {
+    auto errorText = SS("An error occurred while registering a user. Message: " << error.message() << std::endl);
+    _errorManager->setError(errorText);
+  }
 }
 
 void AuthManager::logIn(std::string const& userEmail, std::string const& userPassword) {
-  _app->login(
-          realm::App::credentials::username_password(userEmail, userPassword))
-      .get();
-  _delegate->onLoggedIn();
+  try {
+    _app->login(
+            realm::App::credentials::username_password(userEmail, userPassword))
+        .get();
+    _delegate->onLoggedIn();
+  } catch(realm::app_error const &error) {
+    auto errorText = SS("An error occurred while logging in. Message: " << error.message() << std::endl);
+    _errorManager->setError(errorText);
+  }
 }
 
 void AuthManager::logOut() {
-  auto currentUser = _app->get_current_user();
-  currentUser->log_out().get();
-  _delegate->onLoggedOut();
+  try {
+    auto currentUser = _app->get_current_user();
+    currentUser->log_out().get();
+    _delegate->onLoggedOut();
+  } catch(realm::app_error const &error) {
+    auto errorText = SS("An app error occurred. Message: " << error.message() << std::endl);
+    _errorManager->setError(errorText);
+  }
 }

--- a/sync-todo/v2/generated/cpp/managers/auth_manager.hpp
+++ b/sync-todo/v2/generated/cpp/managers/auth_manager.hpp
@@ -2,6 +2,8 @@
 #define AUTH_MANAGER_HPP
 
 #include <cpprealm/sdk.hpp>
+#include "../managers/error_manager.hpp"
+#include "../ss.hpp"
 
 class AuthManager {
  public:
@@ -11,7 +13,7 @@ class AuthManager {
     virtual void onLoggedOut() = 0;
   };
 
-  explicit AuthManager(Delegate *delegate, realm::App *app);
+  explicit AuthManager(Delegate *delegate, realm::App *app, ErrorManager *errorManager);
 
   void registerUser(std::string const& userEmail, std::string const& userPassword);
 
@@ -22,6 +24,7 @@ class AuthManager {
  private:
   Delegate *_delegate{nullptr};
   realm::App *_app{nullptr};
+  ErrorManager *_errorManager{nullptr};
 };
 
 #endif

--- a/sync-todo/v2/generated/cpp/managers/database_manager.cpp
+++ b/sync-todo/v2/generated/cpp/managers/database_manager.cpp
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-DatabaseManager::DatabaseManager(AppState *appState, HomeControllerState *homeControllerState): _appState(appState), _homeControllerState(homeControllerState) {
+DatabaseManager::DatabaseManager(Delegate *delegate, AppState *appState): _delegate(delegate), _appState(appState) {
   auto user = _appState->app->get_current_user();
 
   // Sync configuration and sync subscription management.
@@ -75,12 +75,10 @@ void DatabaseManager::toggleOfflineMode() {
   auto syncSession = _database->get_sync_session();
   if (syncSession->state() == realm::internal::bridge::sync_session::state::paused) {
     syncSession->resume();
-    _homeControllerState->offlineModeSelection = OfflineModeSelection::offlineModeDisabled;
-    _homeControllerState->offlineModeLabel = "Go Offline";
+    _delegate->onSyncSessionResumed();
   } else if (syncSession->state() == realm::internal::bridge::sync_session::state::active) {
     syncSession->pause();
-    _homeControllerState->offlineModeSelection = OfflineModeSelection::offlineModeEnabled;
-    _homeControllerState->offlineModeLabel = "Go Online";
+    _delegate->onSyncSessionPaused();
   }
 }
 
@@ -93,7 +91,7 @@ void DatabaseManager::toggleSubscriptions() {
   }
   // Note the subscription state at the start of the toggle operation.
   // We'll change it after updating the subscriptions.
-  auto currentSubscriptionState = _homeControllerState->subscriptionSelection;
+  auto currentSubscriptionState = _delegate->getSubscriptionSelection();
 
   _database->subscriptions().update([&](realm::mutable_sync_subscription_set& subs) {
     // If the currentSubscriptionState is `allItems`, toggling it should show only my items.
@@ -108,8 +106,7 @@ void DatabaseManager::toggleSubscriptions() {
                               });
       }
       // Update the subscription selection to reflect the new subscription.
-      _homeControllerState->subscriptionSelection = SubscriptionSelection::myItems;
-      _homeControllerState->subscriptionSelectionLabel = "Switch to All";
+      _delegate->onSubscriptionSelectionMyItems();
 
       // If the currentSubscriptionState is `myItems`, toggling should show all items.
       // Remove the `myItems` subscription and make sure the subscription for the all items is present.
@@ -122,8 +119,7 @@ void DatabaseManager::toggleSubscriptions() {
       }
 
       // Update the subscription selection to reflect the new subscription.
-      _homeControllerState->subscriptionSelection = SubscriptionSelection::allItems;
-      _homeControllerState->subscriptionSelectionLabel = "Switch to Mine";
+      _delegate->onSubscriptionSelectionAllItems();
     }
   }).get();
 

--- a/sync-todo/v2/generated/cpp/managers/database_manager.cpp
+++ b/sync-todo/v2/generated/cpp/managers/database_manager.cpp
@@ -130,8 +130,8 @@ void DatabaseManager::toggleSubscriptions() {
 /** Get a list of all items in the database. Sort it to show the most recent items on top. */
 realm::results<realm::Item> DatabaseManager::getItemList() {
   auto items = _database->objects<realm::Item>();
-  items.sort("_id", false);
-  return items;
+  auto sortedItems = items.sort("_id", false);
+  return sortedItems;
 }
 
 /** Get a list of items in the database, filtered to hide completed items. */
@@ -139,6 +139,6 @@ realm::results<realm::Item> DatabaseManager::getIncompleteItemList() {
   auto items = _database->objects<realm::Item>();
   auto incompleteItems = items.where(
       [](auto const &item) { return item.isComplete == false; });
-  incompleteItems.sort("_id", false);
-  return incompleteItems;
+  auto sortedIncompleteItems = incompleteItems.sort("_id", false);
+  return sortedIncompleteItems;
 }

--- a/sync-todo/v2/generated/cpp/managers/database_manager.hpp
+++ b/sync-todo/v2/generated/cpp/managers/database_manager.hpp
@@ -10,7 +10,16 @@
 
 class DatabaseManager {
  public:
-  DatabaseManager(AppState *appState, HomeControllerState *homeControllerState);
+  struct Delegate {
+    virtual ~Delegate() = default;
+    virtual void onSyncSessionPaused() = 0;
+    virtual void onSyncSessionResumed() = 0;
+    virtual void onSubscriptionSelectionMyItems() = 0;
+    virtual void onSubscriptionSelectionAllItems() = 0;
+    virtual SubscriptionSelection getSubscriptionSelection() = 0;
+  };
+
+  DatabaseManager(Delegate *delegate, AppState *appState);
 
   void addNew(bool newItemIsComplete, std::string newItemSummary);
   void remove(realm::managed<realm::Item> itemToDelete);
@@ -22,12 +31,12 @@ class DatabaseManager {
   realm::results<realm::Item> getIncompleteItemList();
 
  private:
+  Delegate *_delegate{nullptr};
   std::string _allItemSubscriptionName;
   std::string _myItemSubscriptionName;
   std::unique_ptr<realm::db> _database;
   std::string _userId;
   AppState *_appState;
-  HomeControllerState *_homeControllerState;
 };
 
 #endif


### PR DESCRIPTION
- Handle auth errors
- Adjust button and window constraints so the button labels are less likely to disappear
- Use a delegate to have the `HomeController` change its own state, instead of letting `DatabaseManager` mutate its state, per this PR review comment: https://github.com/mongodb-university/realm-template-apps/pull/197#discussion_r1543176629

Note for reviewer: after making this change, IntelliSense is saying the DatabaseManager constructor is never used, and is warning me that the `_delegate` I added to the DatabaseManager may be null. I'm not getting those warnings in the other places that have delegates (AuthManager/AppController, for example). So I think I may have missed something here - BUT it is all working properly.