### PR TITLE
Add GH action to verify all files in /client are also in /generated

### DIFF
--- a/.github/workflows/verify-bluehawk.yml
+++ b/.github/workflows/verify-bluehawk.yml
@@ -1,0 +1,21 @@
+name: Verify Bluehawk Was Run
+
+on: pull_request
+
+jobs:
+  check-bluehawk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure Bluehawk Script Was Run
+        working-directory: sync-todo/v2
+        run: |
+          dir1=client/
+          dir2=generated/
+          if [ `diff $dir1 $dir2 | grep -c 'Only'` == 0 ]
+          then 
+            echo "Passed"
+          else 
+            echo "Fail -- one or more files exist in /client that aren't in /generated."
+            exit 1
+          fi

--- a/.github/workflows/verify-bluehawk.yml
+++ b/.github/workflows/verify-bluehawk.yml
@@ -16,6 +16,8 @@ jobs:
           then 
             echo "Passed"
           else 
-            echo "Fail -- one or more files exist in /client that aren't in /generated."
+            echo "Error: The following files exist in the /sync-todo/v2/client directory that aren't in the /sync-todo/v2/generated directory."
+            echo "Please run the /sync-todo/v2/bluehawk.sh script to generate updated output files."
+            diff $dir1 $dir2 | grep 'Only'
             exit 1
           fi


### PR DESCRIPTION
Adds a github action to verify all files in /client are also in /generated. This ensures that the PR submitter has run bluehawk. 